### PR TITLE
Missverständnisse: Tippfehler in Slide 2 korrigiert

### DIFF
--- a/slides/missverstaendnisse/missverstaendnisse.tex
+++ b/slides/missverstaendnisse/missverstaendnisse.tex
@@ -78,7 +78,7 @@
 	\item Nutzen 2: \textbf{Zensurresistenz}
 	\item Nutzen 3: \textbf{Globales Zahlungsnetzwerk} (\textbf{Portabilität und Teilbarkeit})
 	\only<2->{\footnotetext[1]{Emily Stanhope und der Ökonom Charles Brandt, in ``Review of Economic Philosophy''}}
-}{Es gibt keinen intrinsischen Wert, sondern der Wert entsteht durch gesellschaftliche Zuschreibung und kollektive Akzeptanz\footnotemark}
+}{Es gibt einen intrinsischen Wert, der durch gesellschaftliche Zuschreibung und kollektive Akzeptanz entsteht\footnotemark}
 
 \misconceptionslide[pix/satoshi-breakdown-20250812_121849.jpg]{Zu teuer}{Bitcoin ist zu teuer, den kann sich niemand leisten}{%
 	\item Bitcoin ist in kleinste Einheiten teilbar: \textbf{1 Satoshi}


### PR DESCRIPTION
'keinen' → 'einen' in der Schlussfolgerung zum Missverständnis 'Kein intrinsischer Wert': Die Formulierung bestätigte irrtümlich das Missverständnis statt es zu widerlegen. Satzstruktur ebenfalls angepasst.

https://claude.ai/code/session_017XMnYSR9zBQWyfBG9hRcRw